### PR TITLE
[CI] have MIRAI print its output for debugging

### DIFF
--- a/.github/workflows/rust-mirai.yml
+++ b/.github/workflows/rust-mirai.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: 'libra'
+        fetch-depth: 50 # this is to make sure we obtain the target base commit
     # github base_ref is a lie, we obtain the target base the hard way
     - name: Obtain base reference
       id: obtain_base_ref
@@ -39,13 +40,7 @@ jobs:
             repo: context.repo.repo,
             pull_number: context.payload.pull_request.number,
           });
-          const commit_ref = commits.data[0].sha;
-          const commit = await github.repos.getCommit({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: commit_ref
-          });
-          return commit.data.parents[0].sha;
+          return commits.data[0].parents[0].sha;
     # we build the target base first to only run MIRAI on the changes
     - name: Build target base then checkout PR
       working-directory: ./libra
@@ -54,15 +49,12 @@ jobs:
       run: |
         rustup override set `cat ../MIRAI/rust-toolchain`
         rustup component add rustc-dev
-        git fetch origin $SHA
         git checkout $SHA
         RUSTFLAGS="-Z always_encode_mir" cargo build
         git checkout -
     - name: Run MIRAI on PR
       working-directory: ./libra
-      run: |
-        rustup show
-        RUSTC_WRAPPER=mirai RUSTFLAGS="-Z always_encode_mir" cargo build -q 2> ../mirai_results
+      run: RUSTC_WRAPPER=mirai RUSTFLAGS="-Z always_encode_mir" cargo build -q 2>&1 | tee ../mirai_results
     - name: Post comment with MIRAI warnings
       if: success()
       uses: actions/github-script@0.4.0


### PR DESCRIPTION
Some MIRAI runs have failed, and with the current way we run it we cannot see why on Github.
I replaced:

```
$ [command] > output
```

with:

```
$ [command] 2>&1 | tee ../mirai_results
```

which:

1. redirects stderr to stdout (`2>&1`)
2. prints and save the output to a file (via `tee`)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
