### PR TITLE
[CI] MIRAI is not a check anymore, but a repo dispatch

### DIFF
--- a/.github/workflows/rust-mirai.yml
+++ b/.github/workflows/rust-mirai.yml
@@ -1,8 +1,14 @@
 name: Rust_MIRAI
 
-on:
-  pull_request:
-    types: ['opened', 'synchronize']
+# Why `on: repository_dispatch`?
+#
+# If we trigger this action on pull_request events,
+# then it will run with the forked repo GITHUB_TOKEN
+# this is a problem as it won't allow the action to write 
+# a comment on the PR in the last step.
+#
+# instead, we trigger this remotely via a bot we're running ourselves.
+on: repository_dispatch
 
 jobs:
   install_and_run_MIRAI:
@@ -59,7 +65,7 @@ jobs:
       if: success()
       uses: actions/github-script@0.4.0
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.MIRAI_BOT}}
         script: |
           const fs = require('fs');
           fs.readFile('mirai_results', 'utf-8', (err, data) => {


### PR DESCRIPTION
Github actions are limited for pull requests coming from fork repositories.
This is because when our github action runs, the GITHUB_TOKEN provisioned by Github is the one from the forked repository.
This makes it impossible for the github action to comment on the PR if it finds any issues with MIRAI.

In order to fix this, we will:

- run this action only locally, if triggered (via the `repository_dispatch` hook)
- trigger this remotely via a private bot that detects new PR

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
